### PR TITLE
feat: add user.ini

### DIFF
--- a/lambdas/loader/user.ini
+++ b/lambdas/loader/user.ini
@@ -1,0 +1,2 @@
+[cloudtrail]
+index_rotation = daily


### PR DESCRIPTION
This PR adds a custom `user.ini` to the loader lambda which will rotate logs for cloudtrail on a daily basis. We may change this in the future.